### PR TITLE
Fix: Prevent UI from displaying error when liking a post fails

### DIFF
--- a/src/pages/blog_pages/BlogPostPage.jsx
+++ b/src/pages/blog_pages/BlogPostPage.jsx
@@ -15,9 +15,7 @@ import TableSkeleton from "../../components/blog_components/blog/TableSkeleton";
 function BlogPostPage() {
   const { id } = useParams();
   const dispatch = useDispatch();
-  const { posts, isLoading, errorMessage } = useSelector(
-    (state) => state.posts
-  );
+  const { posts, isLoading } = useSelector((state) => state.posts);
   const post = posts.find((p) => p._id === id);
 
   // Local state flag to ensure the view is incremented only once
@@ -53,8 +51,6 @@ function BlogPostPage() {
         <div className="md:w-[70%] w-full margin-auto px-4">
           {isLoading ? (
             <BlogPostSkeleton />
-          ) : errorMessage ? (
-            <div className="text-red-600">{errorMessage}</div>
           ) : post ? (
             <BlogPostComponent post={post} />
           ) : null}


### PR DESCRIPTION
Previously, when a user tried to like a post multiple times, the backend rejected the request, but the error was displayed in the UI, causing the post to disappear. Now, the error is only logged to the console, and the post remains visible.

## What does this PR do?
Fixes the issue where liking a post multiple times caused an error to be displayed in the UI.
Ensures that backend errors related to duplicate likes are logged to the console instead of being shown to the user.
Prevents the post from disappearing when the error occurs, maintaining UI consistency.
## Related Issues

Closes #53 