### PR TITLE
Fix/mobile input focus zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
     />
     <meta name="theme-color" content="#f9fafb" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/src/components/blog_components/blog_dashboard/users/ProfileComponent.jsx
+++ b/src/components/blog_components/blog_dashboard/users/ProfileComponent.jsx
@@ -266,7 +266,13 @@ const ProfileComponent = () => {
       <ProfileSummaryCard userInfo={userInfo} onEditClick={handleStartEdit} />
 
       {/* Profil Düzenleme Modalı */}
-      <Modal isOpen={isOpen && editMode} onClose={onClose} size="2xl">
+      <Modal
+        isOpen={isOpen && editMode}
+        onClose={onClose}
+        size="2xl"
+        scrollBehavior="inside"
+        placement="center"
+      >
         <ModalContent>
           {(onClose) => (
             <>

--- a/src/components/blog_components/blog_dashboard/users/ProfileComponent.jsx
+++ b/src/components/blog_components/blog_dashboard/users/ProfileComponent.jsx
@@ -190,22 +190,29 @@ const ProfileComponent = () => {
 
   // Form değişikliklerini izleme
   const handleChange = (e) => {
+    // Olay nesnesinin ve hedefinin tanımlı olduğundan emin oluyoruz
+    if (!e || !e.target) return;
+
     const { name, value } = e.target;
 
+    if (!name) return;
+
+    // Derinlemesine nesne özellikleri için
     if (name.includes(".")) {
       const [parent, child] = name.split(".");
-      setFormData({
-        ...formData,
+      setFormData((prevData) => ({
+        ...prevData,
         [parent]: {
-          ...formData[parent],
+          ...(prevData[parent] || {}),
           [child]: value,
         },
-      });
+      }));
     } else {
-      setFormData({
-        ...formData,
+      // Basit özellikler için
+      setFormData((prevData) => ({
+        ...prevData,
         [name]: value,
-      });
+      }));
     }
   };
 
@@ -272,6 +279,33 @@ const ProfileComponent = () => {
         size="2xl"
         scrollBehavior="inside"
         placement="center"
+        classNames={{
+          base: "sm:max-w-[80%] m-0 max-h-[90vh]",
+          header: "border-b-[1px] border-default-100",
+          footer: "border-t-[1px] border-default-100",
+          closeButton: "hover:bg-default-100 active:bg-default-200",
+        }}
+        shouldBlockScroll={true}
+        motionProps={{
+          variants: {
+            enter: {
+              y: 0,
+              opacity: 1,
+              transition: {
+                duration: 0.3,
+                ease: "easeOut",
+              },
+            },
+            exit: {
+              y: 20,
+              opacity: 0,
+              transition: {
+                duration: 0.2,
+                ease: "easeIn",
+              },
+            },
+          },
+        }}
       >
         <ModalContent>
           {(onClose) => (
@@ -279,7 +313,7 @@ const ProfileComponent = () => {
               <ModalHeader className="flex flex-col gap-1">
                 Profil Düzenle
               </ModalHeader>
-              <ModalBody>
+              <ModalBody className="pb-6">
                 <ProfileImageUploader
                   imagePreview={imagePreview}
                   selectedImage={selectedImage}

--- a/src/components/blog_components/blog_dashboard/users/profile-components/ProfileEditForm.jsx
+++ b/src/components/blog_components/blog_dashboard/users/profile-components/ProfileEditForm.jsx
@@ -11,6 +11,11 @@ const ProfileEditForm = ({ formData, handleChange }) => (
       onChange={handleChange}
       variant="bordered"
       isDisabled
+      classNames={{
+        inputWrapper:
+          "group-data-[focus-visible=true]:ring-2 group-data-[focus-visible=true]:ring-offset-0 focus:border-primary",
+        input: "focus:outline-none",
+      }}
     />
     <Input
       label="Tam Ad"
@@ -18,6 +23,11 @@ const ProfileEditForm = ({ formData, handleChange }) => (
       value={formData.fullName}
       onChange={handleChange}
       variant="bordered"
+      classNames={{
+        inputWrapper:
+          "group-data-[focus-visible=true]:ring-2 group-data-[focus-visible=true]:ring-offset-0 focus:border-primary",
+        input: "focus:outline-none",
+      }}
     />
     <Input
       label="E-posta"
@@ -26,6 +36,11 @@ const ProfileEditForm = ({ formData, handleChange }) => (
       onChange={handleChange}
       variant="bordered"
       isDisabled
+      classNames={{
+        inputWrapper:
+          "group-data-[focus-visible=true]:ring-2 group-data-[focus-visible=true]:ring-offset-0 focus:border-primary",
+        input: "focus:outline-none",
+      }}
     />
     <Input
       label="Meslek"
@@ -33,6 +48,11 @@ const ProfileEditForm = ({ formData, handleChange }) => (
       value={formData.occupation}
       onChange={handleChange}
       variant="bordered"
+      classNames={{
+        inputWrapper:
+          "group-data-[focus-visible=true]:ring-2 group-data-[focus-visible=true]:ring-offset-0 focus:border-primary",
+        input: "focus:outline-none",
+      }}
     />
     <Input
       label="Web Sitesi"
@@ -40,6 +60,11 @@ const ProfileEditForm = ({ formData, handleChange }) => (
       value={formData.website}
       onChange={handleChange}
       variant="bordered"
+      classNames={{
+        inputWrapper:
+          "group-data-[focus-visible=true]:ring-2 group-data-[focus-visible=true]:ring-offset-0 focus:border-primary",
+        input: "focus:outline-none",
+      }}
     />
     <Input
       label="Twitter"
@@ -47,6 +72,11 @@ const ProfileEditForm = ({ formData, handleChange }) => (
       value={formData.socialLinks?.twitter}
       onChange={handleChange}
       variant="bordered"
+      classNames={{
+        inputWrapper:
+          "group-data-[focus-visible=true]:ring-2 group-data-[focus-visible=true]:ring-offset-0 focus:border-primary",
+        input: "focus:outline-none",
+      }}
     />
     <Input
       label="LinkedIn"
@@ -54,6 +84,11 @@ const ProfileEditForm = ({ formData, handleChange }) => (
       value={formData.socialLinks?.linkedin}
       onChange={handleChange}
       variant="bordered"
+      classNames={{
+        inputWrapper:
+          "group-data-[focus-visible=true]:ring-2 group-data-[focus-visible=true]:ring-offset-0 focus:border-primary",
+        input: "focus:outline-none",
+      }}
     />
     <Input
       label="GitHub"
@@ -61,6 +96,11 @@ const ProfileEditForm = ({ formData, handleChange }) => (
       value={formData.socialLinks?.github}
       onChange={handleChange}
       variant="bordered"
+      classNames={{
+        inputWrapper:
+          "group-data-[focus-visible=true]:ring-2 group-data-[focus-visible=true]:ring-offset-0 focus:border-primary",
+        input: "focus:outline-none",
+      }}
     />
     <Textarea
       label="Biyografi"
@@ -70,6 +110,11 @@ const ProfileEditForm = ({ formData, handleChange }) => (
       variant="bordered"
       className="col-span-1 md:col-span-2"
       maxLength={500}
+      classNames={{
+        inputWrapper:
+          "group-data-[focus-visible=true]:ring-2 group-data-[focus-visible=true]:ring-offset-0 focus:border-primary",
+        input: "focus:outline-none",
+      }}
     />
   </div>
 );

--- a/src/index.css
+++ b/src/index.css
@@ -21,4 +21,51 @@
     -webkit-overflow-scrolling: touch;
     scroll-behavior: smooth;
   }
+
+  /* Mobil cihazlarda form elemanları için zoom engelleme */
+  @media (max-width: 768px) {
+    input,
+    textarea,
+    select,
+    .nextui-input-wrapper,
+    [contenteditable="true"] {
+      font-size: 14px !important; /* Minimum 14px font büyüklüğü ile mobil zoom engellenir */
+      max-height: none !important;
+      line-height: normal !important;
+    }
+
+    /* NextUI özel form elemanları */
+    .nextui-c-iWjDFM {
+      /* NextUI input container */
+      font-size: 16px !important;
+    }
+
+    .nextui-c-PJLV-ikzDMcp-css {
+      /* NextUI input wrapper */
+      transform: none !important;
+    }
+
+    /* Select ve multi-select için */
+    .nextui-c-hkKjww {
+      font-size: 16px !important;
+    }
+
+    /* NextUI için diğer form elemanları */
+    [class*="nextui-"][class*="input"],
+    [class*="nextui-"][class*="select"],
+    [class*="nextui-"][class*="textarea"] {
+      font-size: 16px !important;
+    }
+  }
+}
+
+/* Mobil zoom sorununu çözmek için özel stiller */
+.mobile-input-fix {
+  transform: scale(1);
+  transform-origin: left top;
+}
+
+/* Input için focus/blur animasyonlarını düzeltme */
+.focus-fix {
+  transition: none !important;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -26,46 +26,15 @@
   @media (max-width: 768px) {
     input,
     textarea,
-    select,
-    .nextui-input-wrapper,
-    [contenteditable="true"] {
-      font-size: 14px !important; /* Minimum 14px font büyüklüğü ile mobil zoom engellenir */
-      max-height: none !important;
-      line-height: normal !important;
-    }
-
-    /* NextUI özel form elemanları */
-    .nextui-c-iWjDFM {
-      /* NextUI input container */
-      font-size: 16px !important;
-    }
-
-    .nextui-c-PJLV-ikzDMcp-css {
-      /* NextUI input wrapper */
-      transform: none !important;
-    }
-
-    /* Select ve multi-select için */
-    .nextui-c-hkKjww {
-      font-size: 16px !important;
-    }
-
-    /* NextUI için diğer form elemanları */
-    [class*="nextui-"][class*="input"],
-    [class*="nextui-"][class*="select"],
-    [class*="nextui-"][class*="textarea"] {
-      font-size: 16px !important;
+    select {
+      font-size: 16px !important; /* iOS'da 16px font minimum zoom engeller */
     }
   }
 }
 
-/* Mobil zoom sorununu çözmek için özel stiller */
-.mobile-input-fix {
-  transform: scale(1);
-  transform-origin: left top;
-}
-
-/* Input için focus/blur animasyonlarını düzeltme */
-.focus-fix {
-  transition: none !important;
+/* Safari ve iOS için özel düzeltmeler */
+@supports (-webkit-touch-callout: none) {
+  .nextui-modal-body {
+    -webkit-overflow-scrolling: touch;
+  }
 }


### PR DESCRIPTION
## 📱 What does this PR do?

- Fixes an issue on mobile devices where users experienced unexpected focus shifts while editing their profiles.
- Ensures that input focus stays strictly on the intended field during profile editing.
- Improves the overall editing experience on smaller screens by preventing accidental blur or focus jumps.

## ✅ How to test?

1. Use a mobile device or emulator to access the profile edit page.
2. Try editing various input fields and ensure focus remains on the selected field.
3. Verify that no unintended scrolls or field jumps occur during input.

## 📌 Related Issues

Closes #94 